### PR TITLE
Convert java rsync to shell script

### DIFF
--- a/sync_backup.sh
+++ b/sync_backup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# sync_backup.sh - Local backup synchronization script
+# Converted from Java code to shell script
+
+# Set strict error handling
+set -euo pipefail
+
+# Function to log error messages with timestamp
+log_error() {
+    echo "[ERROR] $(date '+%Y-%m-%d %H:%M:%S') - $1" >&2
+}
+
+# Function to log info messages with timestamp
+log_info() {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+# Parse command line arguments
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <source_backup_path> <target_dir> [rule_id]"
+    exit 1
+fi
+
+SOURCE_BACKUP_PATH="$1"
+TARGET_DIR="$2"
+RULE_ID="${3:-unknown}"
+
+# 1. Create target directory and check if successful
+log_info "Creating target directory: $TARGET_DIR"
+CREATE_AND_CHECK_RESULT=$(sudo mkdir -p "$TARGET_DIR" 2>&1 && sudo test -d "$TARGET_DIR" && echo "DIR_OK" || echo "DIR_FAILED")
+
+if [ "$CREATE_AND_CHECK_RESULT" != "DIR_OK" ]; then
+    log_error "本地同步失败: 目标目录创建失败, targetDir=$TARGET_DIR, result=$CREATE_AND_CHECK_RESULT"
+    exit 1
+fi
+
+log_info "Target directory created successfully"
+
+# 2. Execute rsync synchronization
+log_info "Starting rsync synchronization from $SOURCE_BACKUP_PATH to $TARGET_DIR"
+SYNC_RESULT=$(sudo rsync -avz --progress "$SOURCE_BACKUP_PATH" "$TARGET_DIR" 2>&1) || RSYNC_EXIT_CODE=$?
+
+# 3. Validate local sync result
+if [ -z "$SYNC_RESULT" ]; then
+    log_error "本地同步失败: ruleId=$RULE_ID, 命令执行无返回结果"
+    exit 1
+fi
+
+# 4. Check for error messages (rsync errors usually contain "error", "failed", "cannot", etc.)
+LOWER_RESULT=$(echo "$SYNC_RESULT" | tr '[:upper:]' '[:lower:]')
+
+if echo "$LOWER_RESULT" | grep -E "(error|failed|cannot|permission denied|no such file)" > /dev/null; then
+    log_error "本地同步失败: ruleId=$RULE_ID, error=$SYNC_RESULT"
+    exit 1
+fi
+
+# Check rsync exit code if it was captured
+if [ "${RSYNC_EXIT_CODE:-0}" -ne 0 ]; then
+    log_error "本地同步失败: ruleId=$RULE_ID, rsync exit code=$RSYNC_EXIT_CODE, output=$SYNC_RESULT"
+    exit 1
+fi
+
+# If we reach here, sync was successful
+log_info "本地同步成功: ruleId=$RULE_ID"
+log_info "Sync output: $SYNC_RESULT"
+
+exit 0

--- a/sync_backup.sh
+++ b/sync_backup.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-# sync_backup.sh - Local backup synchronization script
-# Converted from Java code to shell script
+# sync_backup.sh - 本地备份同步脚本
+# 从 Java 代码转换为 Shell 脚本
 
-# Set strict error handling
+# 设置严格的错误处理
 set -euo pipefail
 
-# Function to log error messages with timestamp
+# 记录错误日志的函数（带时间戳）
 log_error() {
     echo "[ERROR] $(date '+%Y-%m-%d %H:%M:%S') - $1" >&2
 }
 
-# Function to log info messages with timestamp
+# 记录信息日志的函数（带时间戳）
 log_info() {
     echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') - $1"
 }
 
-# Parse command line arguments
+# 解析命令行参数
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <source_backup_path> <target_dir> [rule_id]"
+    echo "用法: $0 <源备份路径> <目标目录> [规则ID]"
     exit 1
 fi
 
@@ -26,8 +26,8 @@ SOURCE_BACKUP_PATH="$1"
 TARGET_DIR="$2"
 RULE_ID="${3:-unknown}"
 
-# 1. Create target directory and check if successful
-log_info "Creating target directory: $TARGET_DIR"
+# 1. 创建目标目录并检查是否成功
+log_info "正在创建目标目录: $TARGET_DIR"
 CREATE_AND_CHECK_RESULT=$(sudo mkdir -p "$TARGET_DIR" 2>&1 && sudo test -d "$TARGET_DIR" && echo "DIR_OK" || echo "DIR_FAILED")
 
 if [ "$CREATE_AND_CHECK_RESULT" != "DIR_OK" ]; then
@@ -35,19 +35,19 @@ if [ "$CREATE_AND_CHECK_RESULT" != "DIR_OK" ]; then
     exit 1
 fi
 
-log_info "Target directory created successfully"
+log_info "目标目录创建成功"
 
-# 2. Execute rsync synchronization
-log_info "Starting rsync synchronization from $SOURCE_BACKUP_PATH to $TARGET_DIR"
+# 2. 执行 rsync 同步
+log_info "开始从 $SOURCE_BACKUP_PATH 同步到 $TARGET_DIR"
 SYNC_RESULT=$(sudo rsync -avz --progress "$SOURCE_BACKUP_PATH" "$TARGET_DIR" 2>&1) || RSYNC_EXIT_CODE=$?
 
-# 3. Validate local sync result
+# 3. 验证本地同步结果
 if [ -z "$SYNC_RESULT" ]; then
     log_error "本地同步失败: ruleId=$RULE_ID, 命令执行无返回结果"
     exit 1
 fi
 
-# 4. Check for error messages (rsync errors usually contain "error", "failed", "cannot", etc.)
+# 4. 检查是否包含错误信息（rsync 错误通常包含 "error", "failed", "cannot" 等关键词）
 LOWER_RESULT=$(echo "$SYNC_RESULT" | tr '[:upper:]' '[:lower:]')
 
 if echo "$LOWER_RESULT" | grep -E "(error|failed|cannot|permission denied|no such file)" > /dev/null; then
@@ -55,14 +55,14 @@ if echo "$LOWER_RESULT" | grep -E "(error|failed|cannot|permission denied|no suc
     exit 1
 fi
 
-# Check rsync exit code if it was captured
+# 检查 rsync 退出码（如果被捕获）
 if [ "${RSYNC_EXIT_CODE:-0}" -ne 0 ]; then
-    log_error "本地同步失败: ruleId=$RULE_ID, rsync exit code=$RSYNC_EXIT_CODE, output=$SYNC_RESULT"
+    log_error "本地同步失败: ruleId=$RULE_ID, rsync 退出码=$RSYNC_EXIT_CODE, 输出=$SYNC_RESULT"
     exit 1
 fi
 
-# If we reach here, sync was successful
+# 如果执行到这里，说明同步成功
 log_info "本地同步成功: ruleId=$RULE_ID"
-log_info "Sync output: $SYNC_RESULT"
+log_info "同步输出: $SYNC_RESULT"
 
 exit 0


### PR DESCRIPTION
Convert Java local backup synchronization logic into a `sync_backup.sh` shell script to replace `machineInfoService.getCommandResultSync()` with direct shell commands and native error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e4e387d-3c0b-45db-af98-be8a0aeb6d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e4e387d-3c0b-45db-af98-be8a0aeb6d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

